### PR TITLE
Update Netlify redirects to get ready for 2025 State of Mozilla

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -37,8 +37,18 @@
   [headers.values]
     Cache-Control = "max-age=86400,public"
 
-# Redirect requests to State of Mozilla 2024
+# Redirect requests to State of Mozilla 2025
 [[redirects]]
   from = "/"
+  to = "https://state-of-mozilla-2025.netlify.app/"
+  status = 301
+
+[[redirects]]
+  from = "/2024"
   to = "https://www.mozilla.org/foundation/annualreport/2024"
+  status = 301
+
+[[redirects]]
+  from = "/rebel"
+  to = "https://state-of-mozilla-2025.netlify.app/rebel"
   status = 301


### PR DESCRIPTION
Redirects have been updated to point to the 2025 State of Mozilla site, including new routes for the homepage, /2024, and /rebel. All relevant redirects now use status 301.