### PR TITLE
Add redirect for /2025 to new site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -49,6 +49,11 @@
   status = 301
 
 [[redirects]]
+  from = "/2025"
+  to = "https://state-of-mozilla-2025.netlify.app/"
+  status = 301
+
+[[redirects]]
   from = "/rebel"
   to = "https://state-of-mozilla-2025.netlify.app/rebel"
   status = 301


### PR DESCRIPTION
Introduces a 301 redirect from /2025 to https://state-of-mozilla-2025.netlify.app/ in netlify.toml to support navigation to the new site.