### PR TITLE
Revert "Add redirect for /2025 to new site"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -49,11 +49,6 @@
   status = 301
 
 [[redirects]]
-  from = "/2025"
-  to = "https://state-of-mozilla-2025.netlify.app/"
-  status = 301
-
-[[redirects]]
   from = "/rebel"
   to = "https://state-of-mozilla-2025.netlify.app/rebel"
   status = 301


### PR DESCRIPTION
Reverts mozilla/stateof#16 - we no longer need the redirect to the netlify site - stateof.mozilla.org now renders the 2025 site